### PR TITLE
Add campaign start and end time, fix keywordId in searchterm report

### DIFF
--- a/search_ads/models/reports.py
+++ b/search_ads/models/reports.py
@@ -166,7 +166,7 @@ def _report(campaign=None,
         for granularity in row['granularity']:
             final_row = copy.copy(base)
             final_row.update(granularity)
-            output.append(convert_to_float_all_amounts_in_row(final_row))
+            output.append(convert_keyword_id_to_string(convert_to_float_all_amounts_in_row(final_row)))
     return pd.DataFrame(output)
 
 
@@ -179,4 +179,10 @@ def convert_to_float_all_amounts_in_row(row):
     for field_name, value in _row.items():
         if isinstance(value, dict) and 'currency' in value:
             _row[field_name] = amount_to_float(value)
+    return _row
+
+
+def convert_keyword_id_to_string(row):
+    _row = copy.copy(row)
+    _row['keywordId'] = str(row['keywordId'])
     return _row

--- a/search_ads/models/reports.py
+++ b/search_ads/models/reports.py
@@ -179,6 +179,7 @@ def convert_to_float_all_amounts_in_row(row):
     for field_name, value in _row.items():
         if isinstance(value, dict) and 'currency' in value:
             _row[field_name] = amount_to_float(value)
+            -row[field_name+'Currency'] = value['currency']
     return _row
 
 

--- a/search_ads/models/store_models.py
+++ b/search_ads/models/store_models.py
@@ -203,6 +203,8 @@ class Campaign(Synchronizable, AppleSerializable):
         self._serving_state_reasons = servingStateReasons
         self._modification_time = modificationTime
         self._storefront = storefront
+        self._start_time = startTime
+        self._end_time = endTime
 
         self.name = name
         self.budget_amount = budgetAmount
@@ -210,8 +212,7 @@ class Campaign(Synchronizable, AppleSerializable):
         self.loc_invoice_details = locInvoiceDetails
         self.budget_orders = budgetOrders
         self.status = status
-        self.start_time = startTime
-        self.end_time = endTime
+
 
         self._negative_keywords = []
         for keyword in negativeKeywords:

--- a/search_ads/models/store_models.py
+++ b/search_ads/models/store_models.py
@@ -169,6 +169,8 @@ class Campaign(Synchronizable, AppleSerializable):
                  storefront=[],
                  adGroups=[],
                  modificationTime=None,
+                 startTime=None,
+                 endTime=None,
                  **kwargs):
         """
         Creates a Campaign object
@@ -188,6 +190,8 @@ class Campaign(Synchronizable, AppleSerializable):
         :param negativeKeywords:
         :param adGroups:
         :param modificationTime:
+        :param startTime:
+        :param endTime:
         :param kwargs:
         """
         self._id = str(id)
@@ -206,6 +210,8 @@ class Campaign(Synchronizable, AppleSerializable):
         self.loc_invoice_details = locInvoiceDetails
         self.budget_orders = budgetOrders
         self.status = status
+        self.start_time = startTime
+        self.end_time = endTime
 
         self._negative_keywords = []
         for keyword in negativeKeywords:


### PR DESCRIPTION
- Added start time and end time to campaigns properties to campaigns
- Cast keywordId to string before creating pandas dataframe (if there are nulls pandas casts ints to floats and all keywordIds become like `[real_id].0`)
